### PR TITLE
Setup nginx on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ services:
   - elasticsearch
 
 before_install:
+  - chmod +x travisnginx/setupnginx.sh
   - sleep 10
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - phantomjs --version
   - whereis phantomjs
   - elasticsearch -v
+  - openssl -v
   - curl -i http://localhost:9200/ #elasticsearch should also be accessible without authentication on port 9200
   - curl -i http://localhost:8080/ #port 8080 is used by nginx reverse proxy to enable basic auth for elasticsearch
   - curl -i jeff:s3cr3t@localhost:8080

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ script:
   - elasticsearch -v
   - curl -i http://localhost:9200/ #elasticsearch should also be accessible without authentication on port 9200
   - curl -i http://localhost:8080/ #port 8080 is used by nginx reverse proxy to enable basic auth for elasticsearch
-  - curl -i john:s3cr3t@localhost:8080
+  - curl -i jeff:s3cr3t@localhost:8080
   - mvn clean install -Pitcases
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ script:
   - phantomjs --version
   - whereis phantomjs
   - elasticsearch -v
-  - openssl -v
   - curl -i http://localhost:9200/ #elasticsearch should also be accessible without authentication on port 9200
   - curl -i http://localhost:8080/ #port 8080 is used by nginx reverse proxy to enable basic auth for elasticsearch
   - curl -i jeff:s3cr3t@localhost:8080

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - elasticsearch-1.7
     packages:
       - elasticsearch
-	  - nginx
+      - nginx
       - realpath
 services:
   - elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,24 @@ addons:
       - elasticsearch-1.7
     packages:
       - elasticsearch
+	  - nginx
+      - realpath
 services:
   - elasticsearch
 
 before_install:
   - sleep 10
 
-install: true
+install:
+  - travisnginx/setupnginx.sh
 
 script:
   - set -e
   - phantomjs --version
   - whereis phantomjs
   - elasticsearch -v
-  - curl http://localhost:9200/
+  - curl -i http://localhost:9200/ #elasticsearch should also be accessible without authentication on port 9200
+  - curl -i http://localhost:8080/ #port 8080 is used by nginx reverse proxy to enable basic auth for elasticsearch
+  - curl -i john:s3cr3t@localhost:8080
   - mvn clean install -Pitcases
+

--- a/travisnginx/README.md
+++ b/travisnginx/README.md
@@ -1,0 +1,5 @@
+# travis CI <-> nginX
+
+This repo uses [elasticsearch](https://www.elastic.co/products/elasticsearch) in integration tests. 
+Basic authentication needs to be tested as well, and since elastic search does not offer any security out of the box, we need
+to use [nginx](https://nginx.org/en/) as reverse proxy, in order to enforce basic authentication.

--- a/travisnginx/README.md
+++ b/travisnginx/README.md
@@ -1,5 +1,5 @@
-# travis CI <-> nginX
+# Travis CI / Nginx / ElasticSearch
 
 This repo uses [elasticsearch](https://www.elastic.co/products/elasticsearch) in integration tests. 
-Basic authentication needs to be tested as well, and since elastic search does not offer any security out of the box, we need
+Basic authentication needs to be tested as well and since elastic search does not offer any security out of the box, we need
 to use [nginx](https://nginx.org/en/) as reverse proxy, in order to enforce basic authentication.

--- a/travisnginx/nginx.conf
+++ b/travisnginx/nginx.conf
@@ -1,0 +1,40 @@
+error_log /tmp/error.log;
+pid /tmp/nginx.pid;
+worker_processes 1;
+
+events {
+	worker_connections 1024;
+}
+
+http {
+    # Set an array of temp and cache file options that will otherwise default to restricted locations accessible only to root.
+    client_body_temp_path /tmp/client_body;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+
+
+    ##
+    # Logging Settings
+    ##
+    access_log /tmp/access.log;
+    error_log /tmp/error.log;
+
+	upstream elasticsearch {
+        server 127.0.0.1:9200;
+    }
+
+    server {
+        listen 8080;
+
+        auth_basic "Protected Elasticsearch";
+        auth_basic_user_file passwords;
+
+        location / {
+            proxy_pass http://elasticsearch;
+            proxy_redirect off;
+        }
+    }
+	
+}

--- a/travisnginx/setupnginx.sh
+++ b/travisnginx/setupnginx.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DIR=$(realpath $(dirname "$0"))
+
+printf "jeff:$(openssl passwd -crypt s3cr3t)n" > passwords
+
+# Start nginx.
+nginx -c "$DIR/nginx.conf"

--- a/travisnginx/setupnginx.sh
+++ b/travisnginx/setupnginx.sh
@@ -5,7 +5,7 @@ set -x
 
 DIR=$(realpath $(dirname "$0"))
 
-printf "jeff:$(openssl passwd -crypt s3cr3t)n" > passwords
+printf "jeff:$(openssl passwd -crypt s3cr3t)n" > $DIR/passwords
 
 # Start nginx.
 nginx -c "$DIR/nginx.conf"

--- a/travisnginx/setupnginx.sh
+++ b/travisnginx/setupnginx.sh
@@ -5,7 +5,7 @@ set -x
 
 DIR=$(realpath $(dirname "$0"))
 
-printf "jeff:$(openssl passwd -crypt s3cr3t)n" > $DIR/passwords
+printf "jeff:$(openssl passwd -crypt s3cr3t)" > $DIR/passwords
 
 # Start nginx.
 nginx -c "$DIR/nginx.conf"


### PR DESCRIPTION
Nginx was setup on travis to provide reverse proxy (basic authentication) for elasticsearch.