### PR TITLE
Decoupled type of documents within an index

### DIFF
--- a/src/main/java/com/amihaiemil/charles/ElasticSearchRepository.java
+++ b/src/main/java/com/amihaiemil/charles/ElasticSearchRepository.java
@@ -179,7 +179,11 @@ public final class ElasticSearchRepository implements Repository {
     private JsonObject prepagePage(WebPage page) throws IOException {
         JsonWebPage jsonPage = new JsonWebPage(page);
         try {
-			return Json.createObjectBuilder().add("id", page.getUrl()).add("page", jsonPage.toJsonObject()).build();
+        	JsonObject parsed = jsonPage.toJsonObject();
+			return Json.createObjectBuilder()
+			    .add("id", page.getUrl())
+			    .add("category", parsed.getString("category"))
+			    .add("page", parsed).build();
 		} catch (JsonProcessingException e) {
 			throw new IOException (e);
 		}

--- a/src/main/java/com/amihaiemil/charles/EsBulkContent.java
+++ b/src/main/java/com/amihaiemil/charles/EsBulkContent.java
@@ -72,12 +72,13 @@ final class EsBulkContent {
 			String id = doc.getString("id", "");
 			String action_and_meta_data;
 			if(id.isEmpty()) {
-			    action_and_meta_data = "{\"index\":{}}";
+			    action_and_meta_data = "{\"index\":{\"_type\":\"" + doc.getString("category") + "\"}}";
 			} else {
-				action_and_meta_data = "{\"index\":{\"_id\":\"" + id + "\"}}";
+				action_and_meta_data = "{\"index\":{\"_type\":\"" + doc.getString("category") + "\", "
+						                + "\"_id\":\"" + id + "\"}}";
 			}
 			sb = sb.append(action_and_meta_data).append("\n");
-			sb = sb.append(doc.toString()).append("\n");
+			sb = sb.append(doc.getJsonObject("page").toString()).append("\n");
 		}
 		return sb.toString();
 	}

--- a/src/main/java/com/amihaiemil/charles/LiveWebPage.java
+++ b/src/main/java/com/amihaiemil/charles/LiveWebPage.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -40,18 +41,34 @@ import org.openqa.selenium.support.PageFactory;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  */
 public final class LiveWebPage implements LivePage {
-    private WebDriver driver;
     
+	/**
+	 * Selenium web driver.
+	 */
+	private WebDriver driver;
+
+    /**
+     * Visible anchors.
+     */
     @FindBys(@FindBy(tagName=("a")))
     private List<WebElement> anchors;
-    
+
+    /**
+     * Text content from the page.
+     */
     @FindBy(tagName=("body"))
     private WebElement body;
-    
+
+    /**
+     * Page logical category. Defaults to "page"
+     */
+    @FindBy(id = "pagectg")
+    private WebElement category;
+
     public LiveWebPage(WebDriver driver, Link l) {
     	this(driver, l.getHref());
     }
-    
+
     public LiveWebPage(WebDriver driver, String url) {
         this.driver = driver;
         this.driver.get(url);
@@ -93,6 +110,17 @@ public final class LiveWebPage implements LivePage {
     	throw new UnsupportedOperationException("#setTextContent");
 	}
 
+    public String getCategory() {
+        try {
+            return this.category.getText();
+        } catch (NoSuchElementException ex) {
+            return "page";
+        }
+    }
+    
+    public void setCategory(String category) {
+    	throw new UnsupportedOperationException("#setCategory");
+	}
     public WebPage snapshot() {
         return new SnapshotWebPage(this);
     }

--- a/src/main/java/com/amihaiemil/charles/SnapshotWebPage.java
+++ b/src/main/java/com/amihaiemil/charles/SnapshotWebPage.java
@@ -37,12 +37,14 @@ public final class SnapshotWebPage implements WebPage {
     private String url;
     private String title;
     private String textContent;
+    private String category;
     private Set<Link> links;
 
     public SnapshotWebPage() {
     	this.url = "";
     	this.title = "";
     	this.textContent = "";
+    	this.category = "";
     	this.links = new HashSet<Link>();
     }
     
@@ -51,6 +53,7 @@ public final class SnapshotWebPage implements WebPage {
         this.url = livePage.getUrl();
         this.title = livePage.getTitle();
         this.textContent = livePage.getTextContent();
+        this.category = livePage.getCategory();
         links = new HashSet<Link>();
         for(Link link : livePage.getLinks()) {
         	links.add(link);
@@ -121,6 +124,16 @@ public final class SnapshotWebPage implements WebPage {
 		} else if (!url.equals(other.url))
 			return false;
 		return true;
+	}
+
+	@Override
+	public String getCategory() {
+		return this.category;
+	}
+
+	@Override
+	public void setCategory(String category) {
+		this.category = category;
 	}
 
 }

--- a/src/main/java/com/amihaiemil/charles/WebPage.java
+++ b/src/main/java/com/amihaiemil/charles/WebPage.java
@@ -27,6 +27,7 @@ package com.amihaiemil.charles;
 
 import java.util.Set;
 
+
 /**
  * Interface for a web page.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -42,10 +43,16 @@ public interface WebPage {
 
     String getUrl();
     void setUrl(String url);
+    
     String getTitle();
     void setTitle(String title);
+    
     String getTextContent();
     void setTextContent(String textContent);
+
+    String getCategory();
+    void setCategory(String category);
+    
     Set<Link> getLinks();
     void setLinks(Set<Link> links);
 }

--- a/src/test/java/com/amihaiemil/charles/ElasticSearchRepositoryITCase.java
+++ b/src/test/java/com/amihaiemil/charles/ElasticSearchRepositoryITCase.java
@@ -59,13 +59,13 @@ public class ElasticSearchRepositoryITCase {
 		pages.add(this.webPage("http://www.amihaiemil.com/index.html"));
 		pages.add(this.webPage("http://eva.amihaiemil.com/index.html"));
     	
-		String indexInfo = "http://localhost:9200/testindex/doctype";
+		String indexInfo = "http://localhost:9200/charlesit";
     	ElasticSearchRepository elasticRepo = new ElasticSearchRepository(indexInfo);
     	elasticRepo.export(pages);
     	
     	Thread.sleep(3000);//indexed docs don't become searchable instantly
     	
-    	JsonObject resp = this.search("*:*", indexInfo);
+    	JsonObject resp = this.search("*:*", indexInfo + "/page");
     	JsonObject  hits = resp.getJsonObject("hits");
     	assertTrue(hits.getInt("total") == 2);
     	JsonArray results = hits.getJsonArray("hits");
@@ -79,7 +79,7 @@ public class ElasticSearchRepositoryITCase {
     	}
     	assertTrue(containsEva);
     }
-    
+
     /**
      * Search the elasticsearch index to check if the index was performed.
      * @param query search query.
@@ -104,7 +104,7 @@ public class ElasticSearchRepositoryITCase {
 			IOUtils.closeQuietly(response);
 		}
     }
-    
+
     /**
 	 * Returns a WebPage.
 	 * @param url URL of the page.
@@ -116,6 +116,7 @@ public class ElasticSearchRepositoryITCase {
 		page.setLinks(new LinkedHashSet<Link>());
 		page.setName("indextest.html");
 		page.setTitle("Intex Test | Title");
+		page.setCategory("page");
 		page.setTextContent("Test content of this awesome test page.");
 		return page;
 	}

--- a/src/test/java/com/amihaiemil/charles/ElasticSearchRepositoryTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/ElasticSearchRepositoryTestCase.java
@@ -102,6 +102,7 @@ public class ElasticSearchRepositoryTestCase {
 		page.setName("indextest.html");
 		page.setTitle("Intex Test | Title");
 		page.setTextContent("Test content of this awesome test page.");
+	    page.setCategory("page");
 		return page;
 	}
 

--- a/src/test/java/com/amihaiemil/charles/EsBulkContentTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/EsBulkContentTestCase.java
@@ -80,8 +80,8 @@ public class EsBulkContentTestCase {
 	@Test
 	public void structuresBulk() throws Exception {
 		List<JsonObject> docs = new ArrayList<JsonObject>();
-		docs.add(Json.createObjectBuilder().add("id", "1").add("name", "Mihai").build());
-		docs.add(Json.createObjectBuilder().add("id", "2").add("name", "Emil").build());
+		docs.add(Json.createObjectBuilder().add("id", "1").add("category", "test").add("name", "Mihai").build());
+		docs.add(Json.createObjectBuilder().add("id", "2").add("category", "test").add("name", "Emil").build());
 		String expected = new String(
 			IOUtils.toByteArray(
 				new FileInputStream(

--- a/src/test/java/com/amihaiemil/charles/EsBulkContentTestCase.java
+++ b/src/test/java/com/amihaiemil/charles/EsBulkContentTestCase.java
@@ -80,8 +80,16 @@ public class EsBulkContentTestCase {
 	@Test
 	public void structuresBulk() throws Exception {
 		List<JsonObject> docs = new ArrayList<JsonObject>();
-		docs.add(Json.createObjectBuilder().add("id", "1").add("category", "test").add("name", "Mihai").build());
-		docs.add(Json.createObjectBuilder().add("id", "2").add("category", "test").add("name", "Emil").build());
+		docs.add(
+		    Json.createObjectBuilder().add("id", "1").add("category", "test")
+		    .add("page", Json.createObjectBuilder().add("content", "Mihai").build())
+		    .build()
+		);
+		docs.add(
+		    Json.createObjectBuilder().add("id", "2").add("category", "test")
+		    .add("page", Json.createObjectBuilder().add("content", "Emil").build())
+		    .build()
+		);
 		String expected = new String(
 			IOUtils.toByteArray(
 				new FileInputStream(

--- a/src/test/java/com/amihaiemil/charles/LiveWebPageITCase.java
+++ b/src/test/java/com/amihaiemil/charles/LiveWebPageITCase.java
@@ -80,6 +80,16 @@ public class LiveWebPageITCase {
 		}
 	}
 	
+    /**
+     * {@link LiveWebPage} can fetch its category.
+     */
+    @Test
+    public void retrievesPageCategory() {
+        String address = "http://www.amihaiemil.com/";
+        LiveWebPage livePage = new LiveWebPage(this.driver, address);
+        assertTrue(livePage.getCategory().equals("page"));
+    }
+	
 	/**
 	 * {@link LiveWebPage} can return the visible text from the page.
 	 */

--- a/src/test/resources/bulkIndexStructure.txt
+++ b/src/test/resources/bulkIndexStructure.txt
@@ -1,4 +1,4 @@
-{"index":{"_id":"1"}}
-{"id":"1","name":"Mihai"}
-{"index":{"_id":"2"}}
-{"id":"2","name":"Emil"}
+{"index":{"_type":"test", "_id":"1"}}
+{"id":"1","category":"test","name":"Mihai"}
+{"index":{"_type":"test", "_id":"2"}}
+{"id":"2","category":"test","name":"Emil"}

--- a/src/test/resources/bulkIndexStructure.txt
+++ b/src/test/resources/bulkIndexStructure.txt
@@ -1,4 +1,4 @@
 {"index":{"_type":"test", "_id":"1"}}
-{"id":"1","category":"test","name":"Mihai"}
+{"content":"Mihai"}
 {"index":{"_type":"test", "_id":"2"}}
-{"id":"2","category":"test","name":"Emil"}
+{"content":"Emil"}


### PR DESCRIPTION
A page's logical category (**_type** within the ES index) will be dicated by the (probably hidden) element with id **pagectg** 

**E.g.**
Maybe a webmaster wants certain pages to be labeled as article about history (so category "history") and others about geography. To make a page belong to the group "history", that page needs to have an element (maybe a hidden span) which contains the text "history" and has the id **pagectg**.

All the pages will belong to the "page" group by default.